### PR TITLE
Updated names for subdivisions of Ombre in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ The development fee will be used to pay for development, exchanges and marketing
 - **Total supply**: **1,000,000,000** coins in first 20 years which is followed by a tail emission each year for inflation.
 - **Coin symbol**: **OMB**
 - **Coin Units**:
-  + 1 Ombrini &nbsp;= 0.000000001 **OMB** (10<sup>-9</sup> - _the smallest coin unit_)
-  + 1 Ombretti = 0.000001 **OMB** (10<sup>-6</sup>)
-  + 1 Ombrecent = 0.001 **OMB** (10<sup>-3</sup>)
+  + 1 Nano-Ombre &nbsp;= 0.000000001 **OMB** (10<sup>-9</sup> - _the smallest coin unit_)
+  + 1 Micro-Ombre = 0.000001 **OMB** (10<sup>-6</sup>)
+  + 1 Milli-Ombre = 0.001 **OMB** (10<sup>-3</sup>)
 - **Hash algorithm**: CryptoNight (Proof-Of-Work)
 - **Emission scheme**: Ombre's block reward changes _every 6-months_ as the following "Camel" distribution* (inspired by _real-world mining production_ like of crude oil, coal etc. that is often slow at first,
 accelerated in the next few years before declined and depleted). This great emission scheme was first introduced in Sumokoin.


### PR DESCRIPTION
Updated the names of the sub-divisions to use the standard metric system prefixes associated with smaller units. 

Feel free to deny this PR, but I think its more clear.