### PR TITLE
Add explicit permission checking and correcting to the wallet.

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -85,7 +85,6 @@ static const struct {
   time_t time;
 } mainnet_hard_forks[] = {
   { 1, 1, 0, 1482806500 },
-  { 2, 21300, 0, 1497657600 }
 };
 static const uint64_t mainnet_hard_fork_version_1_till = (uint64_t)-1;
 
@@ -96,7 +95,6 @@ static const struct {
   time_t time;
 } testnet_hard_forks[] = {
   { 1, 1, 0, 1482806500 },
-  { 2, 5150, 0, 1497181713 }
 };
 static const uint64_t testnet_hard_fork_version_1_till = (uint64_t)-1;
 


### PR DESCRIPTION
This will check if the permissions of the wallet files are strict and corrects them if they aren't.