### PR TITLE
Get the block height from the DB instead of the local counter.

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1700,8 +1700,14 @@ uint64_t BlockchainLMDB::height() const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
+  TXN_PREFIX_RDONLY();
+  int result;
 
-  return m_height;
+  // get current height
+  MDB_stat db_stats;
+  if ((result = mdb_stat(m_txn, m_blocks, &db_stats)))
+    throw0(DB_ERROR(lmdb_error("Failed to query m_blocks: ", result).c_str()));
+  return db_stats.ms_entries;
 }
 
 bool BlockchainLMDB::tx_exists(const crypto::hash& h) const


### PR DESCRIPTION
This is necessary for the block explorer which has the DB open but
doesn't add blocks itself (i.e. it's counter would not be updated).

With this change the block explorer no longer needs to be restarted to see the latest blocks (right now we restart it every 60 seconds to display new content).